### PR TITLE
Log format: log milliseconds

### DIFF
--- a/domain/src/main/resources/logback.xml
+++ b/domain/src/main/resources/logback.xml
@@ -19,7 +19,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -36,7 +36,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
@@ -46,7 +46,7 @@
     
     <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>

--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -19,7 +19,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -36,7 +36,7 @@
             </TimeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
@@ -46,7 +46,7 @@
     
     <appender class="ch.qos.logback.core.ConsoleAppender" name="CONSOLE">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %X{requestId} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>


### PR DESCRIPTION
When using log aggregators, like Elastic Search, the logs are not ordered correctly, because the log timestamps are too vague. We would like the log timestamp to include milliseconds.