### PR TITLE
Bump jersey-client from 2.25.1 to 2.27

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.25.1</version>
+            <version>2.27</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Bumps jersey-client from 2.25.1 to 2.27.

Signed-off-by: dependabot[bot] <support@dependabot.com>