### PR TITLE
Added logic to avoid mt become null in channel

### DIFF
--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/MobileTerminalTestHelper.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/MobileTerminalTestHelper.java
@@ -73,7 +73,7 @@ public class MobileTerminalTestHelper {
         return mobileTerminal;
     }
 
-    private static String generateARandomStringWithMaxLength(int len) {
+    public static String generateARandomStringWithMaxLength(int len) {
         Random random = new Random();
         StringBuilder ret = new StringBuilder();
         for (int i = 0; i < len; i++) {

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
@@ -31,10 +31,7 @@ import org.junit.runner.RunWith;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -562,6 +559,33 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         //check the search result
         returnList = sendMTListQuery(mobileTerminalListQuery);
         assertEquals(1, returnList.getMobileTerminalList().size());
+    }
+
+    @Test
+    public void updateMobileTerminal_ChannelHasNoMobileTerminalTTest() {
+        MobileTerminal mobileTerminal = MobileTerminalTestHelper.createBasicMobileTerminal();
+
+        MobileTerminal created = getWebTarget()
+                .path("mobileterminal")
+                .request(MediaType.APPLICATION_JSON)
+                .post(Entity.json(mobileTerminal), MobileTerminal.class);
+
+        assertNotNull(created);
+
+        UUID channelId = created.getChannels().iterator().next().getId();
+
+        created.getChannels().iterator().next().setMobileTerminal(null);
+
+        MobileTerminal updated = getWebTarget()
+                .path("mobileterminal")
+                .queryParam("comment", "NEW_TEST_COMMENT")
+                .request(MediaType.APPLICATION_JSON)
+                .put(Entity.json(created), MobileTerminal.class);
+
+        assertNotNull(updated);
+        assertEquals(created.getId(), updated.getId());
+        assertEquals(created.getId(), updated.getChannels().iterator().next().getMobileTerminal().getId());
+        assertEquals(channelId, updated.getChannels().iterator().next().getId());
     }
 
     private Asset createAndRestBasicAsset() {

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.time.Duration;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -56,6 +57,37 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
 
         assertTrue(first.isPresent());
         assertEquals(mobileTerminal.getChannels().iterator().next().getName(), first.get().getName());
+    }
+
+    @Test
+    public void createMobileTerminalWithMultipleChannelsTest() {
+        MobileTerminal mobileTerminal = MobileTerminalTestHelper.createBasicMobileTerminal();
+
+        Channel channel2 = new Channel();
+        channel2.setName("VMS");
+        channel2.setFrequencyGracePeriod(Duration.ofSeconds(53000));
+        channel2.setMemberNumber(MobileTerminalTestHelper.generateARandomStringWithMaxLength(3));
+        channel2.setExpectedFrequency(Duration.ofSeconds(7100));
+        channel2.setExpectedFrequencyInPort(Duration.ofSeconds(10400));
+        channel2.setLesDescription("Thrane&Thrane");
+        channel2.setDNID("1" + MobileTerminalTestHelper.generateARandomStringWithMaxLength(3));
+        channel2.setInstalledBy("Mike Great");
+        channel2.setArchived(false);
+        channel2.setConfigChannel(true);
+        channel2.setDefaultChannel(true);
+        channel2.setPollChannel(true);
+        channel2.setMobileTerminal(mobileTerminal);
+
+        mobileTerminal.getChannels().add(channel2);
+
+        MobileTerminal created = getWebTarget()
+                .path("mobileterminal")
+                .request(MediaType.APPLICATION_JSON)
+                .post(Entity.json(mobileTerminal), MobileTerminal.class);
+
+        assertNotNull(created);
+        Set<Channel> channels = created.getChannels();
+        assertEquals(2, channels.size());
     }
 
     @Test

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -135,6 +135,9 @@ public class MobileTerminalServiceBean {
 
         mobileTerminal.setPlugin(updatedPlugin);
 
+        MobileTerminal mt = oldTerminal.getChannels().iterator().next().getMobileTerminal();
+        mobileTerminal.getChannels().forEach(channel -> channel.setMobileTerminal(mt));
+
         //TODO check type
         MobileTerminal updatedTerminal;
         if (oldTerminal.getMobileTerminalType() != null) {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -134,6 +134,8 @@ public class MobileTerminalServiceBean {
         }
 
         mobileTerminal.setPlugin(updatedPlugin);
+        
+        mobileTerminal.getChannels().forEach(channel -> channel.setMobileTerminal(oldTerminal));
 
         //TODO check type
         MobileTerminal updatedTerminal;

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -76,7 +76,7 @@ public class MobileTerminalServiceBean {
 
     public MobileTerminal createMobileTerminal(MobileTerminal mobileTerminal, String username) {
         Set<Channel> channels = mobileTerminal.getChannels();
-        channels.iterator().forEachRemaining(channel -> channel.setMobileTerminal(mobileTerminal));
+        channels.forEach(channel -> channel.setMobileTerminal(mobileTerminal));
         MobileTerminal createdMobileTerminal = terminalDao.createMobileTerminal(mobileTerminal);
         String pluginServiceName = createdMobileTerminal.getPlugin().getPluginServiceName();
         boolean dnidUpdated = configModel.checkDNIDListChange(pluginServiceName);


### PR DESCRIPTION
In order to avoid merge issues in backend, we needed to set mobileTerminal in channel before updating mobileTerminal object.