### PR TITLE
Removing additional serializing id from plugin

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPlugin.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPlugin.java
@@ -11,8 +11,6 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.mobileterminal.entity;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
@@ -38,7 +36,6 @@ import java.util.UUID;
         @NamedQuery(name = MobileTerminalConstants.PLUGIN_FIND_ALL, query = "SELECT p FROM MobileTerminalPlugin p WHERE p.pluginInactive = false"),
         @NamedQuery(name = MobileTerminalConstants.PLUGIN_FIND_BY_SERVICE_NAME, query = "SELECT p FROM MobileTerminalPlugin p WHERE p.pluginServiceName = :serviceName")
 })
-@JsonIdentityInfo(generator = ObjectIdGenerators.UUIDGenerator.class/*, property="id"*/)
 public class MobileTerminalPlugin implements Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
When fetching MobileTerminal list from backend, plugins owned by the MTs are not fully fetched. Just one MT contains the whole plugin object and other MTs use an additional plugin id (JsonIdentityInfo) to reference that plugin. It causes a problem when frontend trying to show details of a MT.