### PR TITLE
Fix for ContactInfo History

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
@@ -451,7 +451,7 @@ public class AssetServiceBean implements AssetService {
 
         List<ContactInfo> contactInfoListByAssetId = contactDao.getContactInfoByAssetId(assetId);
         List<ContactInfo> revisionList = contactDao.getContactInfoRevisionForAssetHistory(contactInfoListByAssetId, updatedDate);
-        revisionList.sort(Comparator.comparing(ContactInfo::getCreateTime));
+        revisionList.sort(Comparator.comparing(ContactInfo::getAssetUpdateTime));
         return revisionList;
     }
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
@@ -432,6 +432,8 @@ public class AssetServiceBean implements AssetService {
         if (asset == null) {
             throw new IllegalArgumentException("Could not find any asset with id: " + contactInfo.getAssetId());
         }
+        ContactInfo old = contactDao.findContactInfo(contactInfo.getId());
+        contactInfo.setCreateTime(old.getCreateTime());
         contactInfo.setUpdatedBy(username);
         contactInfo.setAssetUpdateTime(asset.getUpdateTime());
         return contactDao.updateContactInfo(contactInfo);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/ContactInfo.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/ContactInfo.java
@@ -114,7 +114,12 @@ public class ContactInfo implements Serializable {
     private OffsetDateTime assetUpdateTime;
 
     @PrePersist
-    private void generateNewHistoryId() {
+    private void onPrePersist() {
+        this.historyId = UUID.randomUUID();
+    }
+
+    @PreUpdate
+    private void onPreUpdate() {
         this.historyId = UUID.randomUUID();
     }
 


### PR DESCRIPTION
Contacts information is empty when view detailed history view on asset. It was based on sorting for ContactInfo history list done by createTime but since updated ContactInfos has no createTime, it caused the problem. Sorting is done by asset_updatetime since ContactInfo is a part of Asset update operation.