### PR TITLE
Asset presents double lines of each asset in list

### DIFF
--- a/client/src/test/java/eu/europa/ec/fisheries/uvms/asset/client/AssetClientTest.java
+++ b/client/src/test/java/eu/europa/ec/fisheries/uvms/asset/client/AssetClientTest.java
@@ -83,9 +83,11 @@ public class AssetClientTest extends AbstractClientTest {
         AssetBO assetBo = new AssetBO();
         assetBo.setAsset(AssetHelper.createBasicAsset());
         AssetBO upsertAssetBo = assetClient.upsertAsset(assetBo);
+        AssetDTO created = assetClient.getAssetById(AssetIdentifier.GUID, upsertAssetBo.getAsset().getId().toString());
         AssetBO upsertAssetBo2 = assetClient.upsertAsset(assetBo);
+        AssetDTO updated = assetClient.getAssetById(AssetIdentifier.GUID, upsertAssetBo2.getAsset().getId().toString());
         
-        assertThat(upsertAssetBo.getAsset().getHistoryId(), CoreMatchers.is(upsertAssetBo2.getAsset().getHistoryId()));
+        assertEquals(created.getHistoryId(), updated.getHistoryId());
     }
 
     @Test

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
@@ -139,10 +139,10 @@ public class MobileTerminalRestResource {
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
     public Response assignMobileTerminal(@QueryParam("comment") String comment,
                                          @QueryParam("connectId") UUID connectId,
-                                         UUID guid) {
+                                         UUID mobileTerminalId) {
         LOG.info("Assign mobile terminal invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(connectId, guid, comment, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(connectId, mobileTerminalId, comment, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
@@ -232,9 +232,8 @@ public class AssetServiceBean implements AssetService {
         Asset existingAsset = getAssetByCfrIrcs(createAssetId(asset));
         if (existingAsset != null) {
             asset.setId(existingAsset.getId());
-            asset.setHistoryId(existingAsset.getHistoryId());
         }
-        
+
         if (!AssetComparator.assetEquals(asset, existingAsset)) {
             asset = upsertAsset(asset, username);
         }
@@ -242,13 +241,13 @@ public class AssetServiceBean implements AssetService {
         // Clear and create new contacts and notes for now
         UUID assetId = asset.getId();
         if (assetBo.getContacts() != null) {
-            getContactInfoForAsset(assetId).stream().forEach(c -> deleteContactInfo(c.getId()));
-            assetBo.getContacts().stream().forEach(c -> createContactInfoForAsset(assetId, c, username));
+            getContactInfoForAsset(assetId).forEach(c -> deleteContactInfo(c.getId()));
+            assetBo.getContacts().forEach(c -> createContactInfoForAsset(assetId, c, username));
         }
 
         if (assetBo.getNotes() != null) {
-            getNotesForAsset(assetId).stream().forEach(n -> deleteNote(n.getId()));
-            assetBo.getNotes().stream().forEach(c -> createNoteForAsset(assetId, c, username));
+            getNotesForAsset(assetId).forEach(n -> deleteNote(n.getId()));
+            assetBo.getNotes().forEach(c -> createNoteForAsset(assetId, c, username));
         }
         return assetBo;
     }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/dao/AssetDao.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/dao/AssetDao.java
@@ -121,7 +121,6 @@ public class AssetDao {
     }
 
     public Asset updateAsset(Asset asset) {
-        asset.setHistoryId(UUID.randomUUID());  //this is here bc @preupdate runs even when it should not
         Asset updated = em.merge(asset);
         em.flush();
         return updated;

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
@@ -284,6 +284,10 @@ public class Asset implements Serializable {
         this.historyId = UUID.randomUUID();
     }
 
+    @PreUpdate
+    private void generateNewHistoryIdOnUpdate() {
+        this.historyId = UUID.randomUUID();
+    }
 
     public UUID getId() {
         return id;

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -338,7 +338,7 @@ public class MobileTerminalServiceBean {
         if(terminal.getAsset() != null) {
             throw new IllegalArgumentException("Terminal " + mobileTerminalId + " is already linked to an asset with guid " + connectId);
         }
-        asset.setHistoryId(UUID.randomUUID()); // No @PreUpdate in Asset.
+        asset.getMobileTerminals().add(terminal);
         terminal.setAsset(asset);
         terminal.setUpdateuser(username);
         terminalDao.updateMobileTerminal(terminal);
@@ -360,12 +360,12 @@ public class MobileTerminalServiceBean {
 
         Asset asset = terminal.getAsset();
         terminal.setAsset(null);
-        terminalDao.updateMobileTerminal(terminal);
 
         boolean remove = asset.getMobileTerminals().remove(terminal);
         if(!remove) {
             throw new IllegalArgumentException("Terminal " + guid + " is not linked to an asset with ID " + asset.getId());
         }
+        terminalDao.updateMobileTerminal(terminal);
         return terminal;
     }
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -162,8 +162,8 @@ public class MobileTerminalServiceBean {
         return updatedTerminal;
     }
 
-    public MobileTerminal assignMobileTerminal(UUID connectId, UUID guid, String comment, String username) {
-        MobileTerminal terminalAssign = assignMobileTerminalToCarrier(connectId, guid, comment, username);
+    public MobileTerminal assignMobileTerminal(UUID connectId, UUID mobileTerminalId, String comment, String username) {
+        MobileTerminal terminalAssign = assignMobileTerminalToCarrier(connectId, mobileTerminalId, comment, username);
         try {
             String auditData = AuditModuleRequestMapper.mapAuditLogMobileTerminalAssigned(terminalAssign.getId().toString(), comment, username);
             auditProducer.sendModuleMessage(auditData);
@@ -319,9 +319,9 @@ public class MobileTerminalServiceBean {
         }
     }
 
-    public MobileTerminal assignMobileTerminalToCarrier(UUID connectId, UUID guid, String comment, String username) {
+    public MobileTerminal assignMobileTerminalToCarrier(UUID connectId, UUID mobileTerminalId, String comment, String username) {
 
-        if (guid == null) {
+        if (mobileTerminalId == null) {
             throw new NullPointerException("No Mobile terminalId in request");
         }
         if (connectId == null) {
@@ -333,11 +333,12 @@ public class MobileTerminalServiceBean {
             throw new NotFoundException("No Asset with ID " + connectId + " found. Can not link Mobile Terminal.");
         }
 
-        MobileTerminal terminal = getMobileTerminalEntityById(guid);
+        MobileTerminal terminal = getMobileTerminalEntityById(mobileTerminalId);
 
         if(terminal.getAsset() != null) {
-            throw new IllegalArgumentException("Terminal " + guid + " is already linked to an asset with guid " + connectId);
+            throw new IllegalArgumentException("Terminal " + mobileTerminalId + " is already linked to an asset with guid " + connectId);
         }
+        asset.setHistoryId(UUID.randomUUID()); // No @PreUpdate in Asset.
         terminal.setAsset(asset);
         terminal.setUpdateuser(username);
         terminalDao.updateMobileTerminal(terminal);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/Channel.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/Channel.java
@@ -347,7 +347,6 @@ public class Channel implements Serializable {
 				Objects.equals(archived, channel.archived) &&
 				Objects.equals(updateTime, channel.updateTime) &&
 				Objects.equals(updateUser, channel.updateUser) &&
-				Objects.equals(mobileTerminal, channel.mobileTerminal) &&
 				Objects.equals(name, channel.name) &&
 				Objects.equals(DNID, channel.DNID) &&
 				Objects.equals(expectedFrequency, channel.expectedFrequency) &&

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
@@ -298,7 +298,6 @@ public class MobileTerminal implements Serializable {
 		MobileTerminal that = (MobileTerminal) o;
 		return Objects.equals(id, that.id) &&
 				Objects.equals(historyId, that.historyId) &&
-				Objects.equals(plugin, that.plugin) &&
 				Objects.equals(archived, that.archived) &&
 				Objects.equals(inactivated, that.inactivated) &&
 				source == that.source &&
@@ -309,8 +308,7 @@ public class MobileTerminal implements Serializable {
 				Objects.equals(satelliteNumber, that.satelliteNumber) &&
 				Objects.equals(antenna, that.antenna) &&
 				Objects.equals(transceiverType, that.transceiverType) &&
-				Objects.equals(softwareVersion, that.softwareVersion) &&
-				Objects.equals(channels, that.channels);
+				Objects.equals(softwareVersion, that.softwareVersion);
 	}
 
 	@Override

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPlugin.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPlugin.java
@@ -163,8 +163,7 @@ public class MobileTerminalPlugin implements Serializable {
                 Objects.equals(pluginSatelliteType, that.pluginSatelliteType) &&
                 Objects.equals(pluginInactive, that.pluginInactive) &&
                 Objects.equals(updateTime, that.updateTime) &&
-                Objects.equals(updatedBy, that.updatedBy) &&
-                Objects.equals(capabilities, that.capabilities);
+                Objects.equals(updatedBy, that.updatedBy);
     }
 
     @Override

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPluginCapability.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPluginCapability.java
@@ -126,8 +126,7 @@ public class MobileTerminalPluginCapability implements Serializable {
                 Objects.equals(value, that.value) &&
                 Objects.equals(name, that.name) &&
                 Objects.equals(updateTime, that.updateTime) &&
-                Objects.equals(updatedBy, that.updatedBy) &&
-                Objects.equals(plugin, that.plugin);
+                Objects.equals(updatedBy, that.updatedBy);
     }
 
     @Override

--- a/service/src/test/java/eu/europa/fisheries/uvms/tests/mobileterminal/service/arquillian/MobileTerminalServiceIntTest.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/tests/mobileterminal/service/arquillian/MobileTerminalServiceIntTest.java
@@ -143,28 +143,25 @@ public class MobileTerminalServiceIntTest extends TransactionalTests {
 
     @Test
     @OperateOnDeployment("normal")
-    public void unAssignMobileTerminalFromCarrier() throws HeuristicRollbackException, RollbackException, HeuristicMixedException, SystemException, NotSupportedException {
+    public void unAssignMobileTerminalFromCarrier() {
 
-        MobileTerminal created = testPollHelper.createAndPersistMobileTerminal(null);
-        Asset asset = createAndPersistAsset();
-        assertNotNull(created);
+        MobileTerminal persistMobileTerminal = testPollHelper.createAndPersistMobileTerminal(null);
+        Asset persistAsset = createAndPersistAsset();
+        assertNotNull(persistMobileTerminal.getId());
+        assertNotNull(persistAsset.getId());
 
-        UUID guid = created.getId();
+        UUID mobileTerminalId = persistMobileTerminal.getId();
+        UUID assetId = persistAsset.getId();
 
-        MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(asset.getId(), guid, TEST_COMMENT, USERNAME);
+        MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(assetId, mobileTerminalId, TEST_COMMENT, USERNAME);
         assertNotNull(mobileTerminal);
+        assertNotNull(mobileTerminal.getAsset());
+        assertEquals(1, persistAsset.getMobileTerminals().size());
 
-        userTransaction.commit();
-        userTransaction.begin();
-
-        mobileTerminal.setAsset(asset);
-        mobileTerminal = mobileTerminalService.unAssignMobileTerminal(asset.getId(), guid, TEST_COMMENT, USERNAME);
+        mobileTerminal = mobileTerminalService.unAssignMobileTerminal(assetId, mobileTerminalId, TEST_COMMENT, USERNAME);
         assertNotNull(mobileTerminal);
-
-        assetDao.deleteAsset(asset);
-
-        userTransaction.commit();
-        userTransaction.begin();
+        assertNull(mobileTerminal.getAsset());
+        assertEquals(0, persistAsset.getMobileTerminals().size());
     }
 
     @Test

--- a/service/src/test/java/eu/europa/fisheries/uvms/tests/mobileterminal/service/arquillian/PollProgramDaoBeanIT.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/tests/mobileterminal/service/arquillian/PollProgramDaoBeanIT.java
@@ -464,7 +464,7 @@ public class PollProgramDaoBeanIT extends TransactionalTests {
 
     private OffsetDateTime getStopDate() {
         cal.set(Calendar.DAY_OF_MONTH, 28);
-        cal.set(Calendar.YEAR, 2019);
+        cal.set(Calendar.YEAR, 2059);
         return OffsetDateTime.ofInstant(cal.toInstant(), ZoneOffset.UTC);
     }
 

--- a/service/src/test/java/eu/europa/fisheries/uvms/tests/mobileterminal/service/arquillian/helper/TestPollHelper.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/tests/mobileterminal/service/arquillian/helper/TestPollHelper.java
@@ -271,7 +271,7 @@ public class TestPollHelper {
 
     public OffsetDateTime getStopDate() {
         cal.set(Calendar.DAY_OF_MONTH, 28);
-        cal.set(Calendar.YEAR, 2019);
+        cal.set(Calendar.YEAR, 2059);
         return OffsetDateTime.ofInstant(cal.toInstant(), ZoneOffset.UTC);
     }
 


### PR DESCRIPTION
Assigning MobileTerminal updates Asset as well and since there is no `@PreUpdate` in Asset, it creates a new history with the same ID as before.