### PR TITLE
New notes does not create new Asset history

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
@@ -148,9 +148,12 @@ public class AssetServiceBean implements AssetService {
      */
     @Override
     public Asset updateAsset(Asset asset, String username, String comment) {
-        Asset updatedAsset = updateAssetInternal(asset, username);
-        auditService.logAssetUpdated(updatedAsset, comment, username);
-        return updatedAsset;
+        Asset persistedAsset = assetDao.getAssetById(asset.getId());
+        if (!AssetComparator.assetEquals(asset, persistedAsset)) {
+            persistedAsset = updateAssetInternal(asset, username);
+            auditService.logAssetUpdated(persistedAsset, comment, username);
+        }
+        return persistedAsset;
     }
 
     /**


### PR DESCRIPTION
Avoiding to create a new Asset history when only creating a new Note for that Asset.