### PR TITLE
Child/Parent objects  excluded from Auditing

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.Digits;
@@ -277,6 +278,7 @@ public class Asset implements Serializable {
     @JsonIgnore
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "asset", cascade = CascadeType.ALL)
     @Fetch(FetchMode.SELECT)
+    @NotAudited
     private List<MobileTerminal> mobileTerminals;
 
     @PrePersist

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
@@ -136,6 +136,7 @@ public class MobileTerminal implements Serializable {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name="asset_id", foreignKey = @ForeignKey(name = "MobileTerminal_Asset_FK"))
+	@NotAudited
 	private Asset asset;
 
 	public MobileTerminal() {


### PR DESCRIPTION
Assigning or Unassigning a MobileTerminal to an Asset causes to create an extra history for the other end of the relationship. 