### PR TITLE
Synchronize plugins at startup

### DIFF
--- a/client/src/test/java/eu/europa/ec/fisheries/uvms/asset/client/AbstractClientTest.java
+++ b/client/src/test/java/eu/europa/ec/fisheries/uvms/asset/client/AbstractClientTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractClientTest {
 
 
         testWar.addClass(UnionVMSMock.class);
-        testWar.addClass(ExchangeModuleMock.class);
+        testWar.addClass(ExchangeModuleRestMock.class);
 
         return testWar;
     }

--- a/client/src/test/java/eu/europa/ec/fisheries/uvms/asset/client/ExchangeModuleRestMock.java
+++ b/client/src/test/java/eu/europa/ec/fisheries/uvms/asset/client/ExchangeModuleRestMock.java
@@ -1,0 +1,74 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.asset.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import eu.europa.ec.fisheries.schema.exchange.module.v1.GetServiceListRequest;
+import eu.europa.ec.fisheries.schema.exchange.module.v1.GetServiceListResponse;
+import eu.europa.ec.fisheries.schema.exchange.module.v1.SetCommandRequest;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityListType;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityType;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.CapabilityTypeType;
+import eu.europa.ec.fisheries.schema.exchange.service.v1.ServiceResponseType;
+
+@Path("exchange/rest/api")
+@Stateless
+public class ExchangeModuleRestMock {
+
+    @POST
+    @Path("serviceList")
+    @Consumes(value = {MediaType.APPLICATION_JSON})
+    @Produces(value = {MediaType.APPLICATION_JSON})
+    public GetServiceListResponse getServiceList(GetServiceListRequest request) {
+        try {
+            List<ServiceResponseType> serviceResponse = new ArrayList<ServiceResponseType>();
+            ServiceResponseType serviceResponseType = new ServiceResponseType();
+            serviceResponseType.setServiceClassName("eu.europa.ec.fisheries.uvms.plugins.inmarsat");
+            serviceResponseType.setName("Thrane&Thrane");
+            serviceResponseType.setSatelliteType("INMARSAT_C");
+            serviceResponseType.setActive(true);
+            CapabilityListType capabilityList = new CapabilityListType();
+            CapabilityType capabilityType = new CapabilityType();
+            capabilityType.setType(CapabilityTypeType.POLLABLE);
+            capabilityType.setValue("TRUE");
+            capabilityList.getCapability().add(capabilityType);
+
+            serviceResponseType.setCapabilityList(capabilityList);
+
+            serviceResponse.add(serviceResponseType);
+            GetServiceListResponse response = new GetServiceListResponse();
+            response.getService().addAll(serviceResponse);
+
+            return response;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @POST
+    @Consumes(value = { MediaType.APPLICATION_JSON })
+    @Produces(value = { MediaType.APPLICATION_JSON })
+    @Path("/pluginCommand")
+    public Response sendCommandToPlugin(SetCommandRequest request) {
+        return Response.ok().build();
+    }
+
+}

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
@@ -70,10 +70,8 @@ public class MobileTerminalRestResource {
             terminal.setSource(TerminalSourceEnum.INTERNAL);
 
             MobileTerminalPlugin plugin = pluginDao.getPluginByServiceName(terminal.getPlugin().getPluginServiceName());
-            if(plugin == null) {
-                plugin = pluginDao.initAndGetPlugin(terminal.getPlugin().getPluginServiceName());
-            }
             terminal.setPlugin(plugin);
+
             MobileTerminal mobileTerminal = mobileTerminalService.createMobileTerminal(terminal, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
@@ -107,9 +105,6 @@ public class MobileTerminalRestResource {
             terminal.setSource(TerminalSourceEnum.INTERNAL);
             mobileTerminalService.assertTerminalHasSerialNumber(terminal);
             MobileTerminalPlugin plugin = pluginDao.getPluginByServiceName(terminal.getPlugin().getPluginServiceName());
-            if(plugin == null){
-                pluginDao.initAndGetPlugin(terminal.getPlugin().getPluginServiceName());
-            }
 
             MobileTerminal mobileTerminal = mobileTerminalService.updateMobileTerminal(terminal, comment, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/asset/ExchangeModuleMock.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/asset/ExchangeModuleMock.java
@@ -9,7 +9,7 @@ the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the impl
 FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
 copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
  */
-package eu.europa.ec.fisheries.uvms.asset.client;
+package eu.europa.ec.fisheries.uvms.rest.asset;
 
 import javax.ejb.ActivationConfigProperty;
 import javax.ejb.EJB;

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/dao/MobileTerminalPluginDaoBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/dao/MobileTerminalPluginDaoBean.java
@@ -54,17 +54,6 @@ public class MobileTerminalPluginDaoBean  {
 			return null;
         }
 	}
-	public MobileTerminalPlugin initAndGetPlugin(String serviceName) {
-		MobileTerminalPlugin plugin = null;
-
-		List<ServiceResponseType> serviceTypes = configServiceMT.getRegisteredMobileTerminalPlugins();
-		if(serviceTypes != null) {
-			configServiceMT.upsertPlugins(ServiceToPluginMapper.mapToPluginList(serviceTypes), "PluginTimerBean");
-		}
-		plugin = getPluginByServiceName(serviceName);
-
-		return plugin;
-	}
 
 	public MobileTerminalPlugin updateMobileTerminalPlugin(MobileTerminalPlugin entity)  {
 			return  em.merge(entity);

--- a/service/src/test/java/eu/europa/fisheries/uvms/tests/ExchangeModuleMock.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/tests/ExchangeModuleMock.java
@@ -9,7 +9,7 @@ the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the impl
 FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
 copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
  */
-package eu.europa.ec.fisheries.uvms.asset.client;
+package eu.europa.fisheries.uvms.tests;
 
 import javax.ejb.ActivationConfigProperty;
 import javax.ejb.EJB;


### PR DESCRIPTION
New strategy for synchronizing plugins at startup;
Send a ping so we know when exchange started consuming messages, then wait two seconds before trying to synchronize.
