### PR TITLE
Fixing get mt history list by asset id

### DIFF
--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
@@ -241,7 +241,7 @@ public class MobileTerminalRestResource {
     }
 
     @GET
-    @Path("/history/asset/{assetId}")
+    @Path("/history/mobileterminal/asset/{assetId}")
     @RequiresFeature(UnionVMSFeature.viewVesselsAndMobileTerminals)
     public Response getMobileTerminalHistoryByAssetId(@PathParam("assetId") UUID assetId, @DefaultValue("100") @QueryParam("maxNbr") Integer maxNbr) {
         LOG.info("Get mobile terminal history by asset id invoked in rest layer.");

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/MobileTerminalTestHelper.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/MobileTerminalTestHelper.java
@@ -23,6 +23,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import java.time.Duration;
+import java.util.List;
 import java.util.Random;
 
 public class MobileTerminalTestHelper {
@@ -116,5 +117,25 @@ public class MobileTerminalTestHelper {
                 .path("mobileterminal")
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(mt), MobileTerminal.class);
+    }
+
+    public static MobileTerminalListQuery createMobileTerminalListQueryWithMultipleCriteria(List<String> serialNumberList) {
+        MobileTerminalListQuery query = new MobileTerminalListQuery();
+        MobileTerminalSearchCriteria criteria = new MobileTerminalSearchCriteria();
+
+        // ListPagination
+        ListPagination pagination = new ListPagination();
+        pagination.setListSize(100);
+        pagination.setPage(1);
+        query.setPagination(pagination);
+
+        serialNumberList.forEach(sn -> {
+            ListCriteria crt = new ListCriteria();
+            crt.setKey(SearchKey.SERIAL_NUMBER);
+            crt.setValue(sn);
+            criteria.getCriterias().add(crt);
+        });
+        query.setMobileTerminalSearchCriteria(criteria);
+        return query;
     }
 }

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
@@ -687,7 +687,7 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
                 .put(Entity.json(created2.getId()), MobileTerminal.class);
 
         Map<UUID, List<MobileTerminal>> mtRevisions = getWebTarget()
-                .path("/mobileterminal/history/asset")
+                .path("/mobileterminal/history/mobileterminal/asset")
                 .path(asset.getId().toString())
                 .request(MediaType.APPLICATION_JSON)
                 .get(new GenericType<Map<UUID, List<MobileTerminal>>>() {

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
@@ -672,6 +672,20 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
                 .request(MediaType.APPLICATION_JSON)
                 .put(Entity.json(created2.getId()), MobileTerminal.class);
 
+        getWebTarget()
+                .path("/mobileterminal/unassign")
+                .queryParam("comment", "NEW_TEST_COMMENT")
+                .queryParam("connectId", asset.getId())
+                .request(MediaType.APPLICATION_JSON)
+                .put(Entity.json(created1.getId()), MobileTerminal.class);
+
+        getWebTarget()
+                .path("/mobileterminal/unassign")
+                .queryParam("comment", "NEW_TEST_COMMENT")
+                .queryParam("connectId", asset.getId())
+                .request(MediaType.APPLICATION_JSON)
+                .put(Entity.json(created2.getId()), MobileTerminal.class);
+
         Map<UUID, List<MobileTerminal>> mtRevisions = getWebTarget()
                 .path("/mobileterminal/history/asset")
                 .path(asset.getId().toString())
@@ -818,6 +832,43 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         assertEquals(created.getId(), updated.getId());
         assertEquals(created.getId(), updated.getChannels().iterator().next().getMobileTerminal().getId());
         assertEquals(channelId, updated.getChannels().iterator().next().getId());
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void getMobileTerminalListWithMultipleResultTest() {
+        MobileTerminal mobileTerminal1 = MobileTerminalTestHelper.createBasicMobileTerminal();
+        MobileTerminal mobileTerminal2 = MobileTerminalTestHelper.createBasicMobileTerminal();
+
+        MobileTerminal created1 = getWebTarget()
+                .path("mobileterminal")
+                .request(MediaType.APPLICATION_JSON)
+                .post(Entity.json(mobileTerminal1), MobileTerminal.class);
+
+        MobileTerminal created2 = getWebTarget()
+                .path("mobileterminal")
+                .request(MediaType.APPLICATION_JSON)
+                .post(Entity.json(mobileTerminal2), MobileTerminal.class);
+
+        String serialNr1 = created1.getSerialNo();
+        String serialNr2 = created2.getSerialNo();
+
+        List<String> serialNumberList = Arrays.asList(serialNr1, serialNr2);
+
+        MobileTerminalListQuery mobileTerminalListQuery =
+                MobileTerminalTestHelper.createMobileTerminalListQueryWithMultipleCriteria(serialNumberList);
+
+        MTListResponse response = getWebTarget()
+                .path("/mobileterminal/list")
+                .request(MediaType.APPLICATION_JSON)
+                .post(Entity.json(mobileTerminalListQuery), MTListResponse.class);
+
+        List<MobileTerminal> mtList = response.getMobileTerminalList();
+
+        assertEquals(2, mtList.size());
+
+        assertTrue(mtList.get(0).getSerialNo().equals(serialNr1) || mtList.get(1).getSerialNo().equals(serialNr1));
+        assertTrue(mtList.get(0).getSerialNo().equals(serialNr2) || mtList.get(1).getSerialNo().equals(serialNr2));
     }
 
     private Asset createAndRestBasicAsset() {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
@@ -1,6 +1,7 @@
 package eu.europa.ec.fisheries.uvms.asset.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -275,6 +276,7 @@ public class Asset implements Serializable {
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "asset", cascade = CascadeType.ALL)
     @Fetch(FetchMode.SELECT)
+    @JsonIgnore
     private List<MobileTerminal> mobileTerminals;
 
     @Size(max = 255)

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
@@ -13,7 +13,6 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.envers.Audited;
-import org.hibernate.envers.NotAudited;
 
 import javax.persistence.*;
 import javax.validation.constraints.Digits;
@@ -276,7 +275,6 @@ public class Asset implements Serializable {
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "asset", cascade = CascadeType.ALL)
     @Fetch(FetchMode.SELECT)
-    @NotAudited
     private List<MobileTerminal> mobileTerminals;
 
     @Size(max = 255)

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -40,6 +40,7 @@ import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Stateless
 @LocalBean
@@ -476,10 +477,15 @@ public class MobileTerminalServiceBean {
 
     public Map<UUID, List<MobileTerminal>> getMobileTerminalRevisionsByAssetId(UUID assetId, int maxNbr) {
         Map<UUID, List<MobileTerminal>> revisionMap = new HashMap<>();
-        Asset asset = assetDao.getAssetById(assetId);
-        List<MobileTerminal> mtList = asset.getMobileTerminals();
+        List<Asset> assetRevisions = assetDao.getRevisionsForAsset(assetId);
 
-        mtList.forEach( terminal -> {
+        List<MobileTerminal> mobileTerminals = assetRevisions.stream()
+                .map(Asset::getMobileTerminals)
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
+
+        mobileTerminals.forEach( terminal -> {
             List<MobileTerminal> revisions = terminalDao.getMobileTerminalHistoryById(terminal.getId());
             revisions.sort(Comparator.comparing(MobileTerminal::getCreateTime));
             if (revisions.size() > maxNbr) {


### PR DESCRIPTION
We need auditing on Mobile Terminals in Asset in order to fetch MobileTerminal revisions for a given Asset Id. If an Asset has already an active MobileTerminal then it is not a problem but if Asset unlinked the previous connected MTs, best way to fetch those is through Asset's revision which will contain the earlier linked Mobile Terminals. To solve the "Asset creates a new history when linking/unlinking a Mobile Terminal although Asset itself is intact" problem, the front-end should check if any of Asset fields updated before it sends a PUT request to asset endpoint.