### PR TITLE
Uv 728 json ignore properties

### DIFF
--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
@@ -816,7 +816,6 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
 
         assertNotNull(updated);
         assertEquals(created.getId(), updated.getId());
-        assertEquals(created.getId(), updated.getChannels().iterator().next().getMobileTerminal().getId());
         assertEquals(channelId, updated.getChannels().iterator().next().getId());
     }
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
@@ -1,8 +1,6 @@
 package eu.europa.ec.fisheries.uvms.asset.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
@@ -49,7 +47,6 @@ import static eu.europa.ec.fisheries.uvms.asset.domain.entity.Asset.*;
           @NamedQuery(name = ASSET_FIND_BY_IDS, query = "SELECT v FROM Asset v WHERE v.id in :idList AND v.active = true"),
           @NamedQuery(name = ASSET_FIND_BY_ALL_IDENTIFIERS, query = "SELECT v FROM Asset v WHERE (v.cfr = :cfr OR v.ircs = :ircs OR v.imo = :imo OR v.mmsi = :mmsi OR v.iccat = :iccat OR v.uvi = :uvi OR v.gfcm = :gfcm) AND v.active = true"),
 })
-//@JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property = "id", scope = Asset.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Asset implements Serializable {
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/Asset.java
@@ -49,7 +49,7 @@ import static eu.europa.ec.fisheries.uvms.asset.domain.entity.Asset.*;
           @NamedQuery(name = ASSET_FIND_BY_IDS, query = "SELECT v FROM Asset v WHERE v.id in :idList AND v.active = true"),
           @NamedQuery(name = ASSET_FIND_BY_ALL_IDENTIFIERS, query = "SELECT v FROM Asset v WHERE (v.cfr = :cfr OR v.ircs = :ircs OR v.imo = :imo OR v.mmsi = :mmsi OR v.iccat = :iccat OR v.uvi = :uvi OR v.gfcm = :gfcm) AND v.active = true"),
 })
-@JsonIdentityInfo(generator=ObjectIdGenerators.UUIDGenerator.class)
+//@JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property = "id", scope = Asset.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Asset implements Serializable {
 
@@ -271,7 +271,8 @@ public class Asset implements Serializable {
     @Column(name = "prodorgname")
     private String prodOrgName;
 
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "asset", cascade = {CascadeType.MERGE, CascadeType.REFRESH})
+    @JsonIgnoreProperties(value = {"asset"}, allowSetters = true)
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "asset", cascade = {CascadeType.REFRESH})
     private List<MobileTerminal> mobileTerminals;
 
     @Size(max = 255)

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/AssetGroup.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/AssetGroup.java
@@ -36,7 +36,7 @@ import static eu.europa.ec.fisheries.uvms.asset.domain.entity.AssetGroup.*;
 	@NamedQuery(name=GROUP_ASSET_BY_GUID, query="SELECT a FROM AssetGroup a WHERE a.id = :guid"),
 	@NamedQuery(name=GROUP_ASSET_BY_GUID_LIST, query="SELECT a FROM AssetGroup a WHERE a.archived = false AND a.id IN :guidList")
 })
-@JsonIdentityInfo(generator= ObjectIdGenerators.UUIDGenerator.class)
+@JsonIdentityInfo(generator= ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class AssetGroup implements Serializable {
 
     public static final String GROUP_ASSET_FIND_ALL = "AssetGroup.findAll";

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/AssetGroupField.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/domain/entity/AssetGroupField.java
@@ -33,7 +33,7 @@ import static eu.europa.ec.fisheries.uvms.asset.domain.entity.AssetGroupField.*;
 		@NamedQuery(name=ASSETGROUP_FIELD_CLEAR, query="DELETE  FROM AssetGroupField a where a.assetGroup=:assetgroup"),
 		@NamedQuery(name=ASSETGROUP_RETRIEVE_FIELDS_FOR_GROUP, query="SELECT a  FROM AssetGroupField a where a.assetGroup=:assetgroup"),
 })
-@JsonIdentityInfo(generator= ObjectIdGenerators.UUIDGenerator.class)
+@JsonIdentityInfo(generator= ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class AssetGroupField implements Serializable {
 
     public static final String ASSETGROUP_FIELD_CLEAR = "Assetgroupfield.clear";

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/Channel.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/Channel.java
@@ -54,7 +54,7 @@ import java.util.UUID;
 		uniqueConstraints = {@UniqueConstraint(name = "channel_uc_historyid" , columnNames = "historyid"),
 							 @UniqueConstraint(name = "channel_uc_dnid_member_number" , columnNames = {"dnid", "member_number"})})
 @Audited
-@JsonIdentityInfo(generator=ObjectIdGenerators.UUIDGenerator.class)
+//@JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Channel implements Serializable {
 	private static final long serialVersionUID = 1L;
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
@@ -59,7 +59,7 @@ import java.util.UUID;
             query="SELECT DISTINCT m FROM MobileTerminal m LEFT OUTER JOIN Channel c ON m.id = c.mobileTerminal.id " +
                     "WHERE m.archived = false AND c.archived = false AND c.DNID = :dnid AND c.memberNumber = :memberNumber AND m.mobileTerminalType = :mobileTerminalType")
 })
-@JsonIdentityInfo(generator=ObjectIdGenerators.UUIDGenerator.class/*, property="id"*/)
+//@JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property = "id", scope = MobileTerminal.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MobileTerminal implements Serializable {
 	private static final long serialVersionUID = 1L;
@@ -131,6 +131,7 @@ public class MobileTerminal implements Serializable {
 	@Column(name = "software_version")
 	private String softwareVersion;
 
+	@JsonIgnoreProperties(value = {"mobileTerminal"}, allowSetters = true)
 	@OneToMany(mappedBy = "mobileTerminal", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
 	private Set<Channel> channels;
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminal.java
@@ -11,9 +11,7 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.mobileterminal.entity;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
@@ -59,7 +57,6 @@ import java.util.UUID;
             query="SELECT DISTINCT m FROM MobileTerminal m LEFT OUTER JOIN Channel c ON m.id = c.mobileTerminal.id " +
                     "WHERE m.archived = false AND c.archived = false AND c.DNID = :dnid AND c.memberNumber = :memberNumber AND m.mobileTerminalType = :mobileTerminalType")
 })
-//@JsonIdentityInfo(generator=ObjectIdGenerators.PropertyGenerator.class, property = "id", scope = MobileTerminal.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MobileTerminal implements Serializable {
 	private static final long serialVersionUID = 1L;

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPluginCapability.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/entity/MobileTerminalPluginCapability.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 @NamedQueries({
 	@NamedQuery(name = "PluginCapability.findAll", query = "SELECT p FROM MobileTerminalPluginCapability p"),
 })
-@JsonIdentityInfo(generator=ObjectIdGenerators.UUIDGenerator.class/*, property="id"*/)
+@JsonIdentityInfo(generator= ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class MobileTerminalPluginCapability implements Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
To break circular reference between "Asset - MobileTerminal" and "MobileTerminal - Channel", I added @JsonIgnoreProperties in the child entity.