### PR TITLE
Creating a new updatetime when un/assigning mt to asset

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -39,6 +39,8 @@ import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 
 @Stateless
@@ -339,8 +341,8 @@ public class MobileTerminalServiceBean {
             throw new IllegalArgumentException("Terminal " + mobileTerminalId + " is already linked to an asset with guid " + connectId);
         }
         asset.getMobileTerminals().add(terminal);
-        Asset assetWithMT = assetDao.updateAsset(asset);
-        terminal.setAsset(assetWithMT);
+        asset.setUpdateTime(OffsetDateTime.now(ZoneOffset.UTC));
+        terminal.setAsset(asset);
         terminal.setUpdateuser(username);
         terminal.setComment(comment);
         terminal = terminalDao.updateMobileTerminal(terminal);
@@ -362,7 +364,7 @@ public class MobileTerminalServiceBean {
         if(!remove) {
             throw new IllegalArgumentException("Terminal " + guid + " is not linked to an asset with ID " + asset.getId());
         }
-        assetDao.updateAsset(asset);
+        asset.setUpdateTime(OffsetDateTime.now(ZoneOffset.UTC));
         terminal.setAsset(null);
         terminal.setComment(comment);
         return terminalDao.updateMobileTerminal(terminal);


### PR DESCRIPTION
https://jira.havochvatten.se/jira/browse/UV-743

When assigning / unassigning an MT to an Asset, a new history created in Asset with the last update time since Asset itself is not modified with this operation. As a result, there will be 2 history event in Asset with the same time signature. Here I updated Asset for these operations.  Now we have 2 Asset history with a different update time signature but Asset itself is still not changed.  If we put MT history in the Asset history modal, as we do with contact info, then it would make sense.  Otherwise, it is important to know how do we want to represent this relation in Asset history.