### PR TITLE
Mt rest resource refactor

### DIFF
--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
@@ -11,7 +11,6 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.rest.mobileterminal.services;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.Asset;
@@ -108,7 +107,6 @@ public class MobileTerminalRestResource {
         try {
             terminal.setSource(TerminalSourceEnum.INTERNAL);
             mobileTerminalService.assertTerminalHasSerialNumber(terminal);
-            MobileTerminalPlugin plugin = pluginDao.getPluginByServiceName(terminal.getPlugin().getPluginServiceName());
 
             MobileTerminal mobileTerminal = mobileTerminalService.updateMobileTerminal(terminal, comment, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
@@ -141,7 +139,6 @@ public class MobileTerminalRestResource {
         try {
             MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(
                     query.getConnectId(), query.getMobileTerminalId(), query.getComment(), request.getRemoteUser());
-            objectMapper().enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/services/MobileTerminalRestResource.java
@@ -11,6 +11,7 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.rest.mobileterminal.services;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.Asset;
@@ -18,6 +19,7 @@ import eu.europa.ec.fisheries.uvms.mobileterminal.bean.MobileTerminalServiceBean
 import eu.europa.ec.fisheries.uvms.mobileterminal.dao.MobileTerminalPluginDaoBean;
 import eu.europa.ec.fisheries.uvms.mobileterminal.dto.MTListResponse;
 import eu.europa.ec.fisheries.uvms.mobileterminal.dto.MobileTerminalListQuery;
+import eu.europa.ec.fisheries.uvms.mobileterminal.dto.MobileTerminalRestQuery;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.MobileTerminal;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.MobileTerminalPlugin;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.types.MobileTerminalStatus;
@@ -120,11 +122,10 @@ public class MobileTerminalRestResource {
     @POST
     @Path("/list")
     @RequiresFeature(UnionVMSFeature.viewVesselsAndMobileTerminals)
-    public Response getMobileTerminalList(MobileTerminalListQuery query,
-                                          @DefaultValue("false") @QueryParam("includeArchived") boolean includeArchived) {
+    public Response getMobileTerminalList(MobileTerminalListQuery query) {
         LOG.info("Get mobile terminal list invoked in rest layer.");
         try {
-            MTListResponse mobileTerminalList = mobileTerminalService.getMobileTerminalList(query, includeArchived);
+            MTListResponse mobileTerminalList = mobileTerminalService.getMobileTerminalList(query);
             return Response.ok(mobileTerminalList).build();
         } catch (Exception ex) {
             LOG.error("[ Error when getting mobile terminal list ] {}", ex);
@@ -135,12 +136,12 @@ public class MobileTerminalRestResource {
     @PUT
     @Path("/assign")
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
-    public Response assignMobileTerminal(@QueryParam("comment") String comment,
-                                         @QueryParam("connectId") UUID connectId,
-                                         UUID mobileTerminalId) {
+    public Response assignMobileTerminal(MobileTerminalRestQuery query) {
         LOG.info("Assign mobile terminal invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(connectId, mobileTerminalId, comment, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.assignMobileTerminal(
+                    query.getConnectId(), query.getMobileTerminalId(), query.getComment(), request.getRemoteUser());
+            objectMapper().enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {
@@ -152,12 +153,11 @@ public class MobileTerminalRestResource {
     @PUT
     @Path("/unassign")
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
-    public Response unAssignMobileTerminal(@QueryParam("comment") String comment,
-                                           @QueryParam("connectId") UUID connectId,
-                                           UUID guid) {
+    public Response unAssignMobileTerminal(MobileTerminalRestQuery query) {
         LOG.info("Unassign mobile terminal invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.unAssignMobileTerminal(connectId, guid, comment, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.unAssignMobileTerminal(
+                    query.getConnectId(), query.getMobileTerminalId(), query.getComment(), request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {
@@ -169,10 +169,11 @@ public class MobileTerminalRestResource {
     @PUT
     @Path("/status/activate")
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
-    public Response setStatusActive(@QueryParam("comment") String comment, UUID guid) {
+    public Response setStatusActive(MobileTerminalRestQuery query) {
         LOG.info("Set mobile terminal status active invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(guid, comment, MobileTerminalStatus.ACTIVE, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(
+                    query.getMobileTerminalId(), query.getComment(), MobileTerminalStatus.ACTIVE, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {
@@ -184,10 +185,11 @@ public class MobileTerminalRestResource {
     @PUT
     @Path("/status/inactivate")
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
-    public Response setStatusInactive(@QueryParam("comment") String comment, UUID guid) {
+    public Response setStatusInactive(MobileTerminalRestQuery query) {
         LOG.info("Set mobile terminal status inactive invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(guid, comment, MobileTerminalStatus.INACTIVE, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(
+                    query.getMobileTerminalId(), query.getComment(), MobileTerminalStatus.INACTIVE, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {
@@ -199,10 +201,11 @@ public class MobileTerminalRestResource {
     @PUT
     @Path("/status/remove")
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
-    public Response setStatusRemoved(@QueryParam("comment") String comment, UUID guid) {
+    public Response setStatusRemoved(MobileTerminalRestQuery query) {
         LOG.info("Set mobile terminal status removed invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(guid, comment, MobileTerminalStatus.ARCHIVE, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(
+                    query.getMobileTerminalId(), query.getComment(), MobileTerminalStatus.ARCHIVE, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {
@@ -214,10 +217,11 @@ public class MobileTerminalRestResource {
     @PUT
     @Path("/status/unarchive")
     @RequiresFeature(UnionVMSFeature.manageMobileTerminals)
-    public Response setStatusUnarchived(@QueryParam("comment") String comment, UUID guid) {
+    public Response setStatusUnarchived(MobileTerminalRestQuery query) {
         LOG.info("Set mobile terminal status unarchived invoked in rest layer.");
         try {
-            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(guid, comment, MobileTerminalStatus.UNARCHIVE, request.getRemoteUser());
+            MobileTerminal mobileTerminal = mobileTerminalService.setStatusMobileTerminal(
+                    query.getMobileTerminalId(), query.getComment(),MobileTerminalStatus.UNARCHIVE, request.getRemoteUser());
             String returnString = objectMapper().writeValueAsString(mobileTerminal);
             return Response.ok(returnString).build();
         } catch (Exception ex) {
@@ -229,7 +233,8 @@ public class MobileTerminalRestResource {
     @GET
     @Path("/history/{id}")
     @RequiresFeature(UnionVMSFeature.viewVesselsAndMobileTerminals)
-    public Response getMobileTerminalHistoryListByMobileTerminalId(@PathParam("id") UUID id, @DefaultValue("100") @QueryParam("maxNbr") Integer maxNbr) {
+    public Response getMobileTerminalHistoryListByMobileTerminalId(@PathParam("id") UUID id,
+                                                                   @DefaultValue("100") @QueryParam("maxNbr") Integer maxNbr) {
         LOG.info("Get mobile terminal history by mobile terminal id invoked in rest layer.");
         try {
             List<MobileTerminal> mobileTerminalRevisions = mobileTerminalService.getMobileTerminalRevisions(id, maxNbr);
@@ -264,14 +269,14 @@ public class MobileTerminalRestResource {
     @RequiresFeature(UnionVMSFeature.viewVesselsAndMobileTerminals)
     public Response getAssetRevisionByMobileTerminalId(@PathParam("mobileTerminalId") UUID mobileTerminalId,
                                                        @DefaultValue("100") @QueryParam("maxNbr") Integer maxNbr) {
-    try{
-        List<Asset> assetRevisions = mobileTerminalService.getAssetRevisionsByMobileTerminalId(mobileTerminalId);
-        String returnString = objectMapper().writeValueAsString(assetRevisions);
-        return Response.ok(returnString).build();
-    } catch (Exception ex) {
-        LOG.error("[ Error when getting Asset history by mobileTerminalId ] {}", ex);
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(ExceptionUtils.getRootCause(ex)).build();
-    }
+        try{
+            List<Asset> assetRevisions = mobileTerminalService.getAssetRevisionsByMobileTerminalId(mobileTerminalId);
+            String returnString = objectMapper().writeValueAsString(assetRevisions);
+            return Response.ok(returnString).build();
+        } catch (Exception ex) {
+            LOG.error("[ Error when getting Asset history by mobileTerminalId ] {}", ex);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(ExceptionUtils.getRootCause(ex)).build();
+        }
     }
 
     //needed since eager fetch is not supported by AuditQuery et al, so workaround is to serialize while we still have a DB session active

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetResourceTest.java
@@ -4,6 +4,7 @@ import eu.europa.ec.fisheries.schema.mobileterminal.types.v1.MobileTerminalType;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.Asset;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.ContactInfo;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.Note;
+import eu.europa.ec.fisheries.uvms.mobileterminal.dto.MobileTerminalRestQuery;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.MobileTerminal;
 import eu.europa.ec.fisheries.uvms.rest.asset.AbstractAssetRestTest;
 import eu.europa.ec.fisheries.uvms.rest.asset.AssetHelper;
@@ -191,13 +192,14 @@ public class AssetResourceTest extends AbstractAssetRestTest {
 
         assertFalse(createdMT.getInactivated());
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(createdMT.getId());
+        builder.withComment("assign").withConnectId(createdAsset.getId());
+
         MobileTerminal assignedMT = getWebTarget()
                 .path("mobileterminal")
                 .path("assign")
-                .queryParam("comment", "assign")
-                .queryParam("connectId", createdAsset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(createdMT.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(assignedMT.getAsset().getId());
 
@@ -561,14 +563,15 @@ public class AssetResourceTest extends AbstractAssetRestTest {
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(terminal), MobileTerminal.class);
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(createdMT.getId());
+        builder.withComment("assign").withConnectId(createdAsset.getId());
+
         // Assign MobileTerminal
         MobileTerminal assignedMT = getWebTarget()
                 .path("mobileterminal")
                 .path("assign")
-                .queryParam("comment", "assign")
-                .queryParam("connectId", createdAsset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(createdMT.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         // Verify Updated Asset holds correct MobileTerminal history
         OffsetDateTime firstTimeStamp = OffsetDateTime.now(ZoneOffset.UTC);
@@ -602,6 +605,7 @@ public class AssetResourceTest extends AbstractAssetRestTest {
         createdAsset.setCfr(newCfr);
         getWebTarget()
                 .path("asset")
+                .queryParam("comment", "update")
                 .request(MediaType.APPLICATION_JSON)
                 .put(Entity.json(createdAsset), Asset.class);
 

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/dto/ResponseTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/dto/ResponseTest.java
@@ -64,9 +64,9 @@ public class ResponseTest {
     @Test
     @OperateOnDeployment("normal")
     public void testGetMobileTerminalList() {
-        doReturn(MOBILE_TERMINAL_LIST_RESPONSE).when(mobileTerminalServiceBean).getMobileTerminalList(null, false);
-        Response result = mobileTerminalRestResource.getMobileTerminalList(null, false);
-        Mockito.verify(mobileTerminalServiceBean).getMobileTerminalList(null, false);
+        doReturn(MOBILE_TERMINAL_LIST_RESPONSE).when(mobileTerminalServiceBean).getMobileTerminalList(null);
+        Response result = mobileTerminalRestResource.getMobileTerminalList(null);
+        Mockito.verify(mobileTerminalServiceBean).getMobileTerminalList(null);
         assertEquals(Response.Status.OK.getStatusCode(), result.getStatus());
     }
 

--- a/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
+++ b/rest/src/test/java/eu/europa/ec/fisheries/uvms/rest/mobileterminal/rest/service/MobileTerminalRestResourceTest.java
@@ -12,10 +12,7 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
 package eu.europa.ec.fisheries.uvms.rest.mobileterminal.rest.service;
 
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.Asset;
-import eu.europa.ec.fisheries.uvms.mobileterminal.dto.ListCriteria;
-import eu.europa.ec.fisheries.uvms.mobileterminal.dto.MTListResponse;
-import eu.europa.ec.fisheries.uvms.mobileterminal.dto.MobileTerminalListQuery;
-import eu.europa.ec.fisheries.uvms.mobileterminal.dto.SearchKey;
+import eu.europa.ec.fisheries.uvms.mobileterminal.dto.*;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.Channel;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.MobileTerminal;
 import eu.europa.ec.fisheries.uvms.mobileterminal.entity.types.MobileTerminalTypeEnum;
@@ -497,12 +494,13 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         Asset asset = createAndRestBasicAsset();
         assertNotNull(asset);
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(created.getId());
+        builder.withComment("NEW_TEST_COMMENT").withConnectId(asset.getId());
+
         MobileTerminal response = getWebTarget()
                 .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(response);
         assertEquals(created.getId(), response.getId());
@@ -523,12 +521,13 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         Asset asset = createAndRestBasicAsset();
         assertNotNull(asset);
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(created.getId());
+        builder.withComment("NEW_TEST_COMMENT").withConnectId(asset.getId());
+
         MobileTerminal responseAssign = getWebTarget()
                 .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(responseAssign);
         assertNotNull(responseAssign.getAsset());
@@ -536,10 +535,8 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
 
         MobileTerminal responseUnAssign = getWebTarget()
                 .path("/mobileterminal/unassign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(responseUnAssign);
         assertNull(responseUnAssign.getAsset());
@@ -560,30 +557,35 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         assertFalse(created.getInactivated());
         assertFalse(created.getArchived());
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(created.getId());
+        builder.withComment("Test Comment Inactivate");
+
         MobileTerminal response = getWebTarget()
                 .path("mobileterminal/status/inactivate")
-                .queryParam("comment", "Test Comment Inactivate")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()))
+                .put(Entity.json(builder.build()))
                 .readEntity(MobileTerminal.class);
 
         assertNotNull(response);
         assertTrue(response.getInactivated());
 
+        builder.withComment("Test Comment Activate");
+
         response = getWebTarget()
                 .path("mobileterminal/status/activate")
                 .queryParam("comment", "Test Comment Activate")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()))
+                .put(Entity.json(builder.build()))
                 .readEntity(MobileTerminal.class);
 
         assertFalse(response.getInactivated());
 
+        builder.withComment("Test Comment Remove");
+
         response = getWebTarget()
                 .path("mobileterminal/status/remove")
-                .queryParam("comment", "Test Comment Remove")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()))
+                .put(Entity.json(builder.build()))
                 .readEntity(MobileTerminal.class);
 
         assertTrue(response.getInactivated());
@@ -612,21 +614,24 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         assertFalse(created.getInactivated());
         assertFalse(created.getArchived());
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(created.getId());
+        builder.withComment("Test Comment Archive");
+
         MobileTerminal response = getWebTarget()
                 .path("mobileterminal/status/remove")
-                .queryParam("comment", "Test Comment Archive")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()))
+                .put(Entity.json(builder.build()))
                 .readEntity(MobileTerminal.class);
 
         assertNotNull(response);
         assertTrue(response.getArchived());
 
+        builder.withComment("Test Comment Unarchive");
+
         response = getWebTarget()
                 .path("mobileterminal/status/unarchive")
-                .queryParam("comment", "Test Comment Unarchive")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()))
+                .put(Entity.json(builder.build()))
                 .readEntity(MobileTerminal.class);
 
         assertFalse(response.getArchived());
@@ -658,26 +663,26 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
 
         Asset asset = createAndRestBasicAsset();
 
-        getWebTarget()
-                .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
-                .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created1.getId()), MobileTerminal.class);
+        MobileTerminalRestQuery.QueryBuilder builder1 = new MobileTerminalRestQuery.QueryBuilder(created1.getId());
+        builder1.withComment("NEW_TEST_COMMENT").withConnectId(asset.getId());
+
+        MobileTerminalRestQuery.QueryBuilder builder2 = new MobileTerminalRestQuery.QueryBuilder(created2.getId());
+        builder2.withComment("NEW_TEST_COMMENT").withConnectId(asset.getId());
 
         getWebTarget()
                 .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created2.getId()), MobileTerminal.class);
+                .put(Entity.json(builder1.build()), MobileTerminal.class);
+
+        getWebTarget()
+                .path("/mobileterminal/assign")
+                .request(MediaType.APPLICATION_JSON)
+                .put(Entity.json(builder2.build()), MobileTerminal.class);
 
         getWebTarget()
                 .path("/mobileterminal/unassign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created2.getId()), MobileTerminal.class);
+                .put(Entity.json(builder2.build()), MobileTerminal.class);
 
         List<Map<UUID, List<MobileTerminal>>> mtRevisions = getWebTarget()
                 .path("/mobileterminal/history/asset")
@@ -702,26 +707,25 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         Asset asset1 = createAndRestBasicAsset();
         Asset asset2 = createAndRestBasicAsset();
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(mobileTerminal.getId());
+        builder.withComment("NEW_TEST_COMMENT").withConnectId(asset1.getId());
+
         getWebTarget()
                 .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset1.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(mobileTerminal.getId()));
+                .put(Entity.json(builder.build()));
 
         getWebTarget()
                 .path("/mobileterminal/unassign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset1.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(mobileTerminal.getId()));
+                .put(Entity.json(builder.build()));
+
+        builder.withConnectId(asset2.getId());
 
         getWebTarget()
                 .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset2.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(mobileTerminal.getId()));
+                .put(Entity.json(builder.build()));
 
         List<Asset> assetRevisions = getWebTarget()
                 .path("/mobileterminal/history/mobileterminal")
@@ -755,11 +759,13 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
 
         assertFalse(created.getArchived());
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(created.getId());
+        builder.withComment("Test Comment Remove");
+
         MobileTerminal response = getWebTarget()
                 .path("mobileterminal/status/remove")
-                .queryParam("comment", "Test Comment Remove")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()))
+                .put(Entity.json(builder.build()))
                 .readEntity(MobileTerminal.class);
 
         assertTrue(response.getArchived());
@@ -773,9 +779,10 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
 
         assertEquals(sizeBefore, sizeAfter);
 
+        mobileTerminalListQuery.setIncludeArchived(true);
+
         MTListResponse responseWithArchived = getWebTarget()
                 .path("/mobileterminal/list")
-                .queryParam("includeArchived", true)
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(mobileTerminalListQuery), MTListResponse.class);
 
@@ -802,12 +809,13 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         MTListResponse returnList = sendMTListQuery(mobileTerminalListQuery);
         assertEquals(1, returnList.getMobileTerminalList().size());
 
+        MobileTerminalRestQuery.QueryBuilder builder = new MobileTerminalRestQuery.QueryBuilder(created.getId());
+        builder.withComment("NEW_TEST_COMMENT").withConnectId(asset.getId());
+
         MobileTerminal response = getWebTarget()
                 .path("/mobileterminal/assign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(response);
 
@@ -818,10 +826,8 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         // Unassign
         MobileTerminal responseUnAssign = getWebTarget()
                 .path("/mobileterminal/unassign")
-                .queryParam("comment", "NEW_TEST_COMMENT")
-                .queryParam("connectId", asset.getId())
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(responseUnAssign);
 
@@ -829,12 +835,13 @@ public class MobileTerminalRestResourceTest extends AbstractAssetRestTest {
         returnList = sendMTListQuery(mobileTerminalListQuery);
         assertEquals(1, returnList.getMobileTerminalList().size());
 
+        builder.withComment("Test Comment Inactivate");
+
         //And inactivate
         response = getWebTarget()
                 .path("mobileterminal/status/inactivate")
-                .queryParam("comment", "Test Comment Inactivate")
                 .request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(created.getId()), MobileTerminal.class);
+                .put(Entity.json(builder.build()), MobileTerminal.class);
 
         assertNotNull(response);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -88,8 +88,8 @@ public class MobileTerminalServiceBean {
         return createdMobileTerminal;
     }
 
-    public MTListResponse getMobileTerminalList(MobileTerminalListQuery query, boolean includeArchived) {
-        MTListResponse response = getTerminalListByQuery(query, includeArchived);
+    public MTListResponse getMobileTerminalList(MobileTerminalListQuery query) {
+        MTListResponse response = getTerminalListByQuery(query);
         return response;
     }
 
@@ -388,7 +388,7 @@ public class MobileTerminalServiceBean {
         return upsertedMT;
     }
 
-    public MTListResponse getTerminalListByQuery(MobileTerminalListQuery query, boolean includeArchived) {
+    public MTListResponse getTerminalListByQuery(MobileTerminalListQuery query) {
         if (query == null) {
             throw new IllegalArgumentException("No list query");
         }
@@ -411,7 +411,7 @@ public class MobileTerminalServiceBean {
 
         List<ListCriteria> criterias = query.getMobileTerminalSearchCriteria().getCriterias();
 
-        String searchSql = SearchMapper.createSelectSearchSql(criterias, isDynamic, includeArchived);
+        String searchSql = SearchMapper.createSelectSearchSql(criterias, isDynamic, query.isIncludeArchived());
 
         List<MobileTerminal> terminals = terminalDao.getMobileTerminalsByQuery(searchSql);
 
@@ -454,7 +454,7 @@ public class MobileTerminalServiceBean {
         pagination.setPage(1);
         query.setPagination(pagination);
 
-        MTListResponse mobileTerminalListResponse = getMobileTerminalList(query, false);
+        MTListResponse mobileTerminalListResponse = getMobileTerminalList(query);
         List<MobileTerminal> resultList = mobileTerminalListResponse.getMobileTerminalList();
         return resultList.size() != 1 ? null : resultList.get(0);
     }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/dto/MobileTerminalListQuery.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/dto/MobileTerminalListQuery.java
@@ -9,6 +9,7 @@ public class MobileTerminalListQuery {
 
     private ListPagination pagination;
     private MobileTerminalSearchCriteria mobileTerminalSearchCriteria;
+    private boolean includeArchived = false;
 
     public ListPagination getPagination() {
         return pagination;
@@ -24,6 +25,14 @@ public class MobileTerminalListQuery {
 
     public void setMobileTerminalSearchCriteria(MobileTerminalSearchCriteria mobileTerminalSearchCriteria) {
         this.mobileTerminalSearchCriteria = mobileTerminalSearchCriteria;
+    }
+
+    public boolean isIncludeArchived() {
+        return includeArchived;
+    }
+
+    public void setIncludeArchived(boolean includeArchived) {
+        this.includeArchived = includeArchived;
     }
 
     @Override

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/dto/MobileTerminalRestQuery.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/dto/MobileTerminalRestQuery.java
@@ -1,0 +1,57 @@
+package eu.europa.ec.fisheries.uvms.mobileterminal.dto;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public class MobileTerminalRestQuery implements Serializable {
+
+    private UUID mobileTerminalId;
+    private UUID connectId;
+    private String comment;
+
+    private MobileTerminalRestQuery(/* Required for Jackson*/) {
+    }
+
+    private MobileTerminalRestQuery(QueryBuilder builder) {
+        this.mobileTerminalId = builder.mobileTerminalId;
+        this.connectId = builder.connectId;
+        this.comment = builder.comment;
+    }
+
+    public UUID getMobileTerminalId() {
+        return mobileTerminalId;
+    }
+
+    public UUID getConnectId() {
+        return connectId;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public static class QueryBuilder {
+
+        private UUID mobileTerminalId;
+        private UUID connectId;
+        private String comment;
+
+        public QueryBuilder(UUID mobileTerminalId) {
+            this.mobileTerminalId = mobileTerminalId;
+        }
+
+        public QueryBuilder withConnectId(UUID connectId) {
+            this.connectId = connectId;
+            return this;
+        }
+
+        public QueryBuilder withComment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public MobileTerminalRestQuery build() {
+            return new MobileTerminalRestQuery(this);
+        }
+    }
+}


### PR DESCRIPTION
We have mixed GET parameters with POST request body in most of our rest methods. I tried to separate those in this commit. Lots of PUT request contains 1..n query & path parameters with a request body.  I created a wrapper DTO class for request body and query & path parameters with builder pattern (easy modification in the future).  We should avoid to add GET parameters to POST & PUT methods.

This commit requires an update in the Frontend. If we decide to merge this commit into asset_se then we should wait for Frontend to implement its counterpart as well. 