### PR TITLE
Fetching correct mt revision by asset list call

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/asset/bean/AssetServiceBean.java
@@ -135,9 +135,16 @@ public class AssetServiceBean implements AssetService {
 
         List<Asset> assetEntityList = assetDao.getAssetListSearchPaginated(page, listSize, searchFields, dynamic, includeInactivated);
         // force to load children. FetchType.EAGER didn't work.
+        List<MobileTerminal> terminalList = new ArrayList<>();
         assetEntityList.forEach(asset -> {
             if(asset.getMobileTerminals() != null) {
-                asset.getMobileTerminals().size();
+                List<MobileTerminal> terminals = asset.getMobileTerminals();
+                terminals.forEach(mt -> {
+                    MobileTerminal byId = mobileTerminalService.getMobileTerminalEntityById(mt.getId());
+                    terminalList.add(byId);
+                });
+                asset.getMobileTerminals().clear();
+                asset.getMobileTerminals().addAll(terminalList);
             }
         });
         AssetListResponse listAssetResponse = new AssetListResponse();


### PR DESCRIPTION
Apparently, when we fetch objects from outside of EntityManager, like custom SQL query, Hibernate Audited is not working. It's the same reason why FetchType.EAGER doesn't work. With this additional call via EntityManager, We are getting the latest revision of each MobileTerminal.