### PR TITLE
Fix for channels ordering bug

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -528,7 +528,7 @@ public class MobileTerminalServiceBean {
             asList.sort(Comparator.comparing(Channel::getId));
             Set<Channel> sorted = new LinkedHashSet<>(asList);
             mt.getChannels().clear();
-            mt.setChannels(sorted);
+            mt.getChannels().addAll(sorted);
         }
     }
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/bean/MobileTerminalServiceBean.java
@@ -517,18 +517,18 @@ public class MobileTerminalServiceBean {
 
         return AssetDtoMapper.mapToAssetDtos(
                 mtRevisions.stream()
-                .filter(mt -> mt.getAsset() != null)
-                .map(MobileTerminal::getAsset)
-                .collect(Collectors.toList()));
+                        .filter(mt -> mt.getAsset() != null)
+                        .map(MobileTerminal::getAsset)
+                        .collect(Collectors.toList()));
     }
 
     private void sortChannels(MobileTerminal mt) {
         if(mt.getChannels() != null && !mt.getChannels().isEmpty()) {
             List<Channel> asList = new ArrayList<>(mt.getChannels());
-            TreeSet<Channel> sorted = new TreeSet<>(Comparator.comparing(Channel::getId));
-            sorted.addAll(asList);
+            asList.sort(Comparator.comparing(Channel::getId));
+            Set<Channel> sorted = new LinkedHashSet<>(asList);
             mt.getChannels().clear();
-            mt.getChannels().addAll(sorted);
+            mt.setChannels(sorted);
         }
     }
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/mapper/MobileTerminalDtoMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/mapper/MobileTerminalDtoMapper.java
@@ -9,10 +9,7 @@ import eu.europa.ec.fisheries.uvms.mobileterminal.model.dto.MobileTerminalDto;
 import eu.europa.ec.fisheries.uvms.mobileterminal.model.dto.MobileTerminalPluginCapabilityDto;
 import eu.europa.ec.fisheries.uvms.mobileterminal.model.dto.MobileTerminalPluginDto;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class MobileTerminalDtoMapper {
 
@@ -61,7 +58,7 @@ public class MobileTerminalDtoMapper {
     }
 
     public static Set<ChannelDto> mapToChannelDtos(Set<Channel> channels){
-        Set<ChannelDto> dtoSet = new HashSet<>(channels.size());
+        Set<ChannelDto> dtoSet = new LinkedHashSet<>(channels.size());
         for (Channel channel : channels) {
             dtoSet.add(mapToChannelDto(channel));
         }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/mapper/PluginMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/mobileterminal/mapper/PluginMapper.java
@@ -74,8 +74,6 @@ public class PluginMapper {
     }
 
     public static boolean equals(MobileTerminalPlugin entity, PluginService plugin) {
-
-
         if (!entity.getName().equalsIgnoreCase(plugin.getLabelName())) {
             return false;
         }
@@ -177,17 +175,16 @@ public class PluginMapper {
     private static List<? extends CapabilityOption> mapCapabilityOption(TerminalCapability capabilityValue, List<OceanRegionEnum> oceanRegionList, List<MobileTerminalPlugin> lesList) {
         switch (capabilityValue) {
             case SUPPORT_SINGLE_OCEAN:
-                return mapOceanRegions(oceanRegionList);
             case SUPPORT_MULTIPLE_OCEAN:
                 return mapOceanRegions(oceanRegionList);
             case PLUGIN:
-                return mapLandearthstation(lesList);
+                return mapLandEarthStation(lesList);
             default:
                 return null;
         }
     }
 
-    private static List<? extends CapabilityOption> mapLandearthstation(List<MobileTerminalPlugin> lesList) {
+    private static List<? extends CapabilityOption> mapLandEarthStation(List<MobileTerminalPlugin> lesList) {
         List<LandEarthStationType> landEarthStations = new ArrayList<>();
         if (lesList != null) {
             for (MobileTerminalPlugin les : lesList) {


### PR DESCRIPTION
We are sorting the channels in the MT entity but later on, we are mapping entities to DTOs for response objects. For that reason, we are losing the sorting effect since DTOs had HashSet implementation.