### PR TITLE
Fix for creating filter

### DIFF
--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetFilterListRestResourceAdapter.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetFilterListRestResourceAdapter.java
@@ -1,11 +1,9 @@
 package eu.europa.ec.fisheries.uvms.rest.asset.service;
 
+import java.io.StringReader;
 import java.util.Set;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import javax.json.*;
 import javax.json.bind.adapter.JsonbAdapter;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.AssetFilter;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.AssetFilterList;
@@ -27,16 +25,17 @@ public class AssetFilterListRestResourceAdapter implements JsonbAdapter<AssetFil
 	    		
 	    		for(AssetFilterValue assetFilterValue : assetFilterValues) {
 	    			if(!assetFilterQuery.getIsNumber()) {
-	    				jsonValueArray
-	    					.add(assetFilterValue.getValueString());
+						JsonReader jsonReader = Json.createReader(new StringReader(assetFilterValue.getValueString()));
+						JsonValue object = jsonReader.readValue();
+						jsonValueArray.add(object);
+						jsonReader.close();
 	        		}
 	    			else {
 	    				JsonObject jsonValueObject = Json.createObjectBuilder()
 	        				.add("operator", assetFilterValue.getOperator())
 	        				.add("value", assetFilterValue.getValueNumber())
 	        				.build();
-	    				jsonValueArray
-	    					.add(jsonValueObject);
+	    				jsonValueArray.add(jsonValueObject);
 	        		}
 	    		}
 	    		JsonObject jsonQueryBuilder =  Json.createObjectBuilder()

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetFilterRestResponseAdapter.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetFilterRestResponseAdapter.java
@@ -1,14 +1,11 @@
 package eu.europa.ec.fisheries.uvms.rest.asset.service;
 
+import java.io.StringReader;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import javax.json.*;
 import javax.json.bind.adapter.JsonbAdapter;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.AssetFilter;
 import eu.europa.ec.fisheries.uvms.asset.domain.entity.AssetFilterQuery;
@@ -28,7 +25,10 @@ public class AssetFilterRestResponseAdapter implements JsonbAdapter<AssetFilter,
 
     		for(AssetFilterValue assetFilterValue : assetFilterValues) {
     			if(!assetFilterQuery.getIsNumber()) {
-    				jsonValueArray.add(assetFilterValue.getValueString());
+					JsonReader jsonReader = Json.createReader(new StringReader(assetFilterValue.getValueString()));
+					JsonValue object = jsonReader.readValue();
+    				jsonValueArray.add(object);
+					jsonReader.close();
         		}
     			else {
     				JsonObject jsonValueObject = Json.createObjectBuilder()
@@ -43,7 +43,7 @@ public class AssetFilterRestResponseAdapter implements JsonbAdapter<AssetFilter,
     			.add("inverse", assetFilterQuery.getInverse())
     			.add("isNumber", assetFilterQuery.getIsNumber())
     			.add("type", assetFilterQuery.getType())
-    			.add("values",jsonValueArray.build())
+    			.add("values", jsonValueArray.build())
     			.build();
 
     		jsonArrayListOfQueries.add(jsonQueryBuilder);

--- a/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetFilterRestResponseAdapter.java
+++ b/rest/src/main/java/eu/europa/ec/fisheries/uvms/rest/asset/service/AssetFilterRestResponseAdapter.java
@@ -27,7 +27,7 @@ public class AssetFilterRestResponseAdapter implements JsonbAdapter<AssetFilter,
     			if(!assetFilterQuery.getIsNumber()) {
 					JsonReader jsonReader = Json.createReader(new StringReader(assetFilterValue.getValueString()));
 					JsonValue object = jsonReader.readValue();
-    				jsonValueArray.add(object);
+					jsonValueArray.add(object);
 					jsonReader.close();
         		}
     			else {


### PR DESCRIPTION
This fix removes the extra characters (**"\"**) from the response as shown below.

`values":["\"dad80846-be59-4399-b377-e697e3d6caf5\""]`

The problem occurs when adding raw `String` into `JsonArrayBuilder` instead of a `JsonValue`.