### PR TITLE
[unionvms-4542] Fixed query generation for search

### DIFF
--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/bean/AssetDomainModelBean.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/bean/AssetDomainModelBean.java
@@ -150,7 +150,7 @@ public class AssetDomainModelBean {
         Set<AssetHistory> assetHistories = new HashSet<>();
         for (AssetGroup group : dbAssetGroups) {
             List<SearchKeyValue> searchFields = SearchFieldMapper.createSearchFieldsFromGroupCriterias(group.getSearchFields());
-            String sql = SearchFieldMapper.createSelectSearchSql(searchFields, group.isDynamic());
+            String sql = SearchFieldMapper.createSelectSearchSql(searchFields);
             List<AssetHistory> tmp = assetDao.getAssetListSearchNotPaginated(sql, searchFields);
             assetHistories.addAll(tmp);
         }
@@ -171,7 +171,6 @@ public class AssetDomainModelBean {
         }
 
         if (query.getAssetSearchCriteria() == null
-                || query.getAssetSearchCriteria().isIsDynamic() == null
                 || query.getAssetSearchCriteria().getCriterias() == null) {
             throw new InputArgumentException(
                     "Cannot get asset list because criteria are null.");
@@ -188,12 +187,10 @@ public class AssetDomainModelBean {
         int page = query.getPagination().getPage();
         int listSize = query.getPagination().getListSize();
 
-        boolean isDynamic = query.getAssetSearchCriteria().isIsDynamic();
-
         List<SearchKeyValue> searchFields = SearchFieldMapper.createSearchFields(query.getAssetSearchCriteria().getCriterias());
-        String sql = SearchFieldMapper.createSelectSearchSql(searchFields, isDynamic);
+        String sql = SearchFieldMapper.createSelectSearchSql(searchFields);
 
-        String countSql = SearchFieldMapper.createCountSearchSql(searchFields, isDynamic);
+        String countSql = SearchFieldMapper.createCountSearchSql(searchFields);
         Long numberOfAssets = assetDao.getAssetCount(countSql, searchFields);
 
         int numberOfPages = 0;
@@ -226,7 +223,7 @@ public class AssetDomainModelBean {
         eu.europa.ec.fisheries.uvms.entity.assetgroup.AssetGroup group = assetGroupDaoBean.getAssetGroupByGuid(guid);
         List<eu.europa.ec.fisheries.wsdl.asset.group.AssetGroupSearchField> assetGroupSearchFields = generateSearchFields(group);
         List<SearchKeyValue> searchKeyValues = createSearchFieldsFromGroupCriterias(assetGroupSearchFields );
-        String sql = SearchFieldMapper.createSelectSearchSql(searchKeyValues, Boolean.TRUE.equals(group.getDynamic()) , occurrenceDate);
+        String sql = SearchFieldMapper.createSelectSearchSql(searchKeyValues , occurrenceDate);
         return assetDao.getAssetListSearchPaginated(page,listSize,sql,searchKeyValues);
     }
 
@@ -235,16 +232,14 @@ public class AssetDomainModelBean {
             throw new InputArgumentException("Cannot get asset list count because query is null.");
         }
         if (query.getAssetSearchCriteria() == null
-                || query.getAssetSearchCriteria().isIsDynamic() == null
                 || query.getAssetSearchCriteria().getCriterias() == null) {
             throw new InputArgumentException("Cannot get asset list count because criteria are null.");
         }
         if (query.getPagination() == null) {
             throw new InputArgumentException("Cannot get asset list count because criteria pagination is null.");
         }
-        boolean isDynamic = query.getAssetSearchCriteria().isIsDynamic();
         List<SearchKeyValue> searchFields = SearchFieldMapper.createSearchFields(query.getAssetSearchCriteria().getCriterias());
-        String countSql = SearchFieldMapper.createCountSearchSql(searchFields, isDynamic);
+        String countSql = SearchFieldMapper.createCountSearchSql(searchFields);
         return assetDao.getAssetCount(countSql, searchFields);
 
     }

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/mapper/SearchFieldMapper.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/mapper/SearchFieldMapper.java
@@ -184,34 +184,20 @@ public class SearchFieldMapper {
         return builder.toString();
     }
 
-    private static String createSearchSql(List<SearchKeyValue> criterias, boolean dynamic, boolean fetch, Date dateOfEvent) {
-
-        String OPERATOR = " OR ";
-        if (dynamic) {
-            OPERATOR = " AND ";
-        }
+    private static String createSearchSql(List<SearchKeyValue> criterias, boolean fetch, Date dateOfEvent) {
 
         StringBuilder builder = new StringBuilder();
         builder.append(" FROM AssetHistory {asset_history_alias} ");
         builder.append(getJoin(fetch, JoinType.INNER)).append("{asset_history_alias}.asset {asset_alias}");
         builder.append(getJoin(fetch, JoinType.INNER)).append("{asset_alias}.carrier {carrier_alias}");
-
         builder.append(" WHERE {asset_history_alias}.active IN (").append(getHistoryCriterias(criterias)).append(") ");
 
         if (!criterias.isEmpty()) {
 
             builder.append("AND ( ");
-
             //Add the filters
-            boolean first = true;
             for (SearchKeyValue entry : criterias) {
-                if (first) {
-                    first = false;
-                } else {
-                    builder.append(OPERATOR);
-                }
                 SearchFields entrySF = entry.getSearchField();
-
                 if(entrySF.getFieldType()== SearchFieldType.LIST){
                     builder.append(" UPPER(REPLACE(");
                     builder.append(entrySF.getSearchTable().getTableAlias()).append(".").append(entrySF.getFieldName());
@@ -239,11 +225,15 @@ public class SearchFieldMapper {
                 } else if (entrySF.getFieldType().equals(SearchFieldType.MAX_DECIMAL)) {
                     builder.append(" <= :").append(entrySF.getValueName());
                 } else if (entrySF.getFieldType().equals(SearchFieldType.BOOLEAN)) {
-                	builder.append(" = :").append(entrySF.getValueName());
+                    builder.append(" = :").append(entrySF.getValueName());
                 } else {
                     builder.append(" IN (:").append(entrySF.getValueName()).append(") ");
                 }
+                builder.append(" AND ");
             }
+            // remove last AND
+            int lastAndIdx = builder.lastIndexOf(" AND ");
+            builder.replace(lastAndIdx,lastAndIdx+5,"");
             builder.append(" ) ");
         }
 
@@ -255,41 +245,39 @@ public class SearchFieldMapper {
         return builder.toString();
     }
 
-    public static String createSelectSearchSql(List<SearchKeyValue> searchFields, boolean isDynamic) {
-        return createSelectSearchSql(searchFields,isDynamic, null);
+    public static String createSelectSearchSql(List<SearchKeyValue> searchFields) {
+        return createSelectSearchSql(searchFields, null);
     }
 
     /**
      * Create JPQL query for distinct AssetHistory entities
      * @param searchFields List of SearchKeyValue
-     * @param isDynamic if true appends 'AND' operator between where criteria generated from SearchKeyValue entries
      * @param dateOfEvent if exists appends where criteria for first AssetHistory with dateOfEvent occurred before that time
-     * @return
+     * @return generated select assets jpql query
      */
-    public static String createSelectSearchSql(List<SearchKeyValue> searchFields, boolean isDynamic, Date dateOfEvent) {
+    public static String createSelectSearchSql(List<SearchKeyValue> searchFields, Date dateOfEvent) {
         StringBuilder buffer = new StringBuilder();
         buffer.append("SELECT DISTINCT {asset_history_alias}");
-        buffer.append(createSearchSql(searchFields, isDynamic, true, dateOfEvent));
+        buffer.append(createSearchSql(searchFields, true, dateOfEvent));
         buffer.append(" ORDER BY {asset_history_alias}.").append(AssetHistory_.ID).append(" DESC");
         String query = replaceParams(buffer);
         LOG.debug("Primary SQL full: {}",query);
         return query;
     }
 
-    public static String createCountSearchSql(List<SearchKeyValue> searchFields, boolean isDynamic) {
-        return createCountSearchSql(searchFields,isDynamic,null);
+    public static String createCountSearchSql(List<SearchKeyValue> searchFields) {
+        return createCountSearchSql(searchFields,null);
     }
     /**
      * Create JPQL query for count distinct Asset GUID
      * @param searchFields List of SearchKeyValue
-     * @param isDynamic if true appends 'AND' operator between where criteria generated from SearchKeyValue entries
      * @param dateOfEvent if exists appends where criteria for first AssetHistory with dateOfEvent occurred before that time
-     * @return
+     * @return generated count assets jpql query
      */
-    public static String createCountSearchSql(List<SearchKeyValue> searchFields, boolean isDynamic, Date dateOfEvent) {
+    public static String createCountSearchSql(List<SearchKeyValue> searchFields, Date dateOfEvent) {
         StringBuilder buffer = new StringBuilder();
         buffer.append("SELECT COUNT( DISTINCT {asset_alias}.guid )");
-        buffer.append(createSearchSql(searchFields, isDynamic, false , dateOfEvent));
+        buffer.append(createSearchSql(searchFields, false , dateOfEvent));
         String query = replaceParams(buffer);
         LOG.debug("Count SQL full: {}", query);
         return query;

--- a/domain/src/test/java/eu/europa/ec/fisheries/uvms/mapper/SearchFieldMapperTest.java
+++ b/domain/src/test/java/eu/europa/ec/fisheries/uvms/mapper/SearchFieldMapperTest.java
@@ -51,7 +51,7 @@ public class SearchFieldMapperTest {
 
         searchFields.add(searchValue);
 
-        String createSelectSearchSql = SearchFieldMapper.createSelectSearchSql(searchFields, true);
+        String createSelectSearchSql = SearchFieldMapper.createSelectSearchSql(searchFields);
         String expected = "active IN (true,false)";
         assertThat(createSelectSearchSql, containsString(expected));
     }
@@ -66,7 +66,7 @@ public class SearchFieldMapperTest {
 
         searchFields.add(searchValue);
 
-        String createSelectSearchSql = SearchFieldMapper.createSelectSearchSql(searchFields, true);
+        String createSelectSearchSql = SearchFieldMapper.createSelectSearchSql(searchFields);
         String expected = "active IN (true)";
         assertThat(createSelectSearchSql, containsString(expected));
     }


### PR DESCRIPTION
isDynamic flag used to define separating criterion AND/OR between columns users chose to search, which was hardcoded to false client side and by default true when a group was saved, therefore removed that parameters from backend service and is by default appending AND